### PR TITLE
refactor: replace ExecCmd with Cmd in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import com.typesafe.sbt.packager.docker.ExecCmd
+import com.typesafe.sbt.packager.docker.Cmd
 import sbtdynver.DynVer
 
 ThisBuild / organization := "samson.ph"
@@ -38,7 +38,7 @@ lazy val cli = atbpModule("cli")
         Nil
       }
     },
-    dockerCommands += ExecCmd(
+    dockerCommands += Cmd(
       // format: off
       "RUN",
       "apt-get", "update",


### PR DESCRIPTION
Update the Docker command configuration in build.sbt to use 
Cmd instead of ExecCmd for better compatibility with the 
latest sbt-packager library. This change ensures that the 
build process adheres to the current best practices and 
improves maintainability.