### PR TITLE
refactor: update Docker commands for improved readability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,15 +38,16 @@ lazy val cli = atbpModule("cli")
         Nil
       }
     },
-    dockerCommands += Cmd(
-      // format: off
-      "RUN",
-      "apt-get", "update",
-      "&&", "apt-get", "install", "-y", "graphviz",
-      "&&", "apt-get", "autoremove",
-      "&&", "apt-get", "clean",
-      "&&", "rm", "-rf", "/var/lib/apt/lists/*"
-      // format: on
+    dockerCommands ++= Seq(
+      Cmd("USER", "root"),
+      Cmd(
+        "RUN",
+        "apt-get update",
+        "&& apt-get install -y graphviz",
+        "&& apt-get autoremove",
+        "&& apt-get clean",
+        "&& rm -rf /var/lib/apt/lists/*"
+      )
     )
   )
 


### PR DESCRIPTION
Refactor the Docker commands in the build.sbt file to enhance 
readability and maintainability. Replace the single command with 
a sequence of commands, explicitly setting the user to "root" 
before executing the installation commands for graphviz. This 
change improves clarity and aligns with best practices for 
Dockerfile structure.