### PR TITLE
feat: enhance CLI help documentation and options

### DIFF
--- a/cli/src/main/scala/ph/samson/atbp/cli/Conf.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Conf.scala
@@ -27,9 +27,10 @@ case class Conf(
 
 object Conf {
   val Descriptor: Config[Conf] = deriveConfig[Conf]
+  val Resolver = config("atbp")
 
   val appConf: Task[Conf] = for {
-    config <- ZIO.attemptBlockingIO(config("atbp").load)
+    config <- ZIO.attemptBlockingIO(Resolver.load)
     provider <- ConfigProvider.fromTypesafeConfigZIO(config.getConfig("atbp"))
     conf <- provider.load(Descriptor)
   } yield conf

--- a/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
@@ -8,6 +8,8 @@ import zio.ZLayer
 import zio.cli.CliApp
 import zio.cli.Command
 import zio.cli.HelpDoc
+import zio.cli.HelpDoc.*
+import zio.cli.HelpDoc.Span.*
 import zio.cli.Options
 import zio.cli.ZIOCliDefault
 import zio.config.typesafe.TypesafeConfigProvider
@@ -27,19 +29,44 @@ object Main extends ZIOCliDefault {
         "(dev)"
   }
 
-  val verbose = Options.boolean("verbose").alias("v")
-  val quiet = Options.boolean("quiet").alias("q")
+  val verbose = Options.boolean("verbose").alias("v") ?? "Print out debug logs."
+  val quiet = Options.boolean("quiet").alias("q") ??
+    "Only print warning logs. Takes precedence over verbose flag."
   val logging = verbose ++ quiet
 
-  val atbp = Command(Name, logging).subcommands(
-    Markdown2Confluence.command,
-    Plate.command
-  )
+  val atbp = Command(Name, logging)
+    .subcommands(
+      Markdown2Confluence.command,
+      Plate.command
+    )
+    .withHelp(
+      blocks(
+        p(
+          "Unrelated tools that I'm too lazy to build and package and install" +
+            " separately. Each tool is its own command. See list below."
+        ),
+        p(
+          spans(
+            text("Use "),
+            code("atbp <command> --help"),
+            text(" for specific help for each tool.")
+          )
+        ),
+        h2("Configuration"),
+        p(
+          spans(
+            text("User configuration is read from "),
+            code(Conf.Resolver.get("application.conf").pathAsString),
+            text(" as a HOCON formatted file.")
+          )
+        )
+      )
+    )
 
   override def cliApp = CliApp.make(
     name = Name,
     version = Version,
-    summary = HelpDoc.Span.text("Assorted tooling bits and pieces"),
+    summary = text("Assorted tooling bits and pieces"),
     command = atbp
   ) { case ((verbose, quiet), toolCommand) =>
     val run = for {

--- a/cli/src/main/scala/ph/samson/atbp/cli/Markdown2Confluence.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Markdown2Confluence.scala
@@ -9,6 +9,7 @@ import zio.ZIO
 import zio.cli.Args
 import zio.cli.Command
 import zio.cli.Exists.Yes
+import zio.cli.HelpDoc.*
 import zio.cli.Options
 import zio.http.ZClient
 
@@ -60,15 +61,22 @@ object Markdown2Confluence {
 
   private val sourceDir = Args.directory("sourceDir", Yes).atMost(1)
   private val cleanup =
-    Options.boolean("cleanup") ?? "Remove drafts from the space"
+    Options.boolean("cleanup") ?? "Remove drafts from the space."
 
   val command: Command[Markdown2Confluence] =
-    Command("md2c", cleanup, sourceDir).map { (c, s) =>
-      Markdown2Confluence(
-        sourceDir = s match
-          case Nil      => File.currentWorkingDirectory
-          case dir :: _ => dir,
-        cleanup = c
+    Command("md2c", cleanup, sourceDir)
+      .withHelp(
+        blocks(
+          h2("Markdown to Confluence"),
+          p("Publish a directory of Markdown documents to Confluence.")
+        )
       )
-    }
+      .map { (c, s) =>
+        Markdown2Confluence(
+          sourceDir = s match
+            case Nil      => File.currentWorkingDirectory
+            case dir :: _ => dir,
+          cleanup = c
+        )
+      }
 }


### PR DESCRIPTION
Add detailed help descriptions for the verbose and quiet 
options in the CLI. Improve the help documentation for 
the main command and the Markdown to Confluence command 
to provide users with clearer guidance on usage and 
configuration. Refactor command definitions for better 
readability and maintainability.