### PR TITLE
refactor: remove unused PHT variable from Check object

### DIFF
--- a/cli/src/main/scala/ph/samson/atbp/cli/Plate.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Plate.scala
@@ -12,8 +12,6 @@ import zio.cli.Exists.Yes
 import zio.cli.Options
 import zio.http.ZClient
 
-import java.time.ZoneId
-
 case class Plate(action: Action) extends ToolCommand {
   override def run(conf: Conf): ZIO[Any, Throwable, Unit] = action.run(conf)
 }
@@ -70,8 +68,6 @@ object Plate {
   }
 
   private object Check {
-    val PHT = ZoneId.of("Asia/Manila")
-
     sealed trait Status
     case object Cooking extends Status
     case object Stale extends Status


### PR DESCRIPTION
Eliminate the unused PHT variable from the Check object in Plate.scala. 
This change cleans up the code and improves readability by removing 
unnecessary declarations.