### PR TITLE
Fix version formatting

### DIFF
--- a/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
@@ -23,10 +23,10 @@ object Main extends ZIOCliDefault {
     // read version info from JAR manifest
     val pak = Main.getClass.getPackage
     Option(pak.getImplementationVersion) match {
-      case Some(version) => version
+      case Some(version) => s" v$version"
       case None          =>
         // we're running unpackaged
-        "(dev)"
+        " (dev)"
     }
   }
 


### PR DESCRIPTION
They've changed how zio-cli formats version. This is needed unless https://github.com/zio/zio-cli/pull/406 gets accepted.