### PR TITLE
chore: update AdfBuilderJava version to 1.7.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys.*
 object Dependencies {
 
   object Versions {
-    val AdfBuilderJava = "0.48.0"
+    val AdfBuilderJava = "1.7.0"
     val CommonMark = "0.24.0"
     val Zio = "2.1.17"
     val ZioConfig = "4.0.4"


### PR DESCRIPTION
Updates the AdfBuilderJava dependency from version 0.48.0 to 1.7.0 
to incorporate the latest features and improvements. This change 
ensures compatibility with other dependencies and enhances overall 
project stability.