### PR TITLE
fix: reverse tail requests to maintain correct order

### DIFF
--- a/jira/src/main/scala/ph/samson/atbp/jira/Client.scala
+++ b/jira/src/main/scala/ph/samson/atbp/jira/Client.scala
@@ -79,7 +79,7 @@ object Client {
           } else reqs
         }
 
-        if (head.length < head.total) tailRequests(Nil) else Nil
+        if (head.length < head.total) tailRequests(Nil).reverse else Nil
       }
 
       ZIO.scoped(ZIO.logSpan("search") {


### PR DESCRIPTION
Change tailRequests result to be reversed before returning when
head.length is less than head.total. This ensures the requests are
processed in the correct order, preventing potential issues with
out-of-order handling in the client search logic.