### PR TITLE
fix: exclude completed issues from sorting at each level

### DIFF
--- a/plate/src/main/scala/ph/samson/atbp/plate/Sorter.scala
+++ b/plate/src/main/scala/ph/samson/atbp/plate/Sorter.scala
@@ -111,7 +111,7 @@ object Sorter {
       @tailrec
       def doSort(level: Int, sorts: List[Task[Unit]]): List[Task[Unit]] = {
         if (level <= levels.max) {
-          val issues = sourceAtLevel(level)
+          val issues = sourceAtLevel(level).filterNot(_.isDone)
           val targetOrder = issues.map(_.key).distinct
 
           val levelSort = ZIO.logSpan(s"doSort $level") {


### PR DESCRIPTION
Filter out issues marked as done before sorting to avoid unnecessary
processing and ensure only active issues are considered during the
sorting operation. This improves efficiency and correctness of the
sorter logic.