### PR TITLE
fix(publish): add sonatypeCredentialHost setting for publish

### DIFF
--- a/publish.sbt
+++ b/publish.sbt
@@ -14,4 +14,5 @@ ThisBuild / developers := List(
   )
 )
 
+ThisBuild / sonatypeCredentialHost := Sonatype.sonatypeCentralHost
 sonatypeProfileName := "ph.samson"


### PR DESCRIPTION
Set ThisBuild / sonatypeCredentialHost to Sonatype.sonatypeCentralHost
to ensure correct credentials are used when publishing to Sonatype.  
This change fixes publishing issues related to missing host configuration.

See: https://github.com/sbt/sbt-ci-release?tab=readme-ov-file#how-do-i-publish-to-sonatype-central