### PR TITLE
fix(publish): remove deprecated Sonatype settings

### DIFF
--- a/publish.sbt
+++ b/publish.sbt
@@ -13,6 +13,3 @@ ThisBuild / developers := List(
     url("https://edward.samson.ph")
   )
 )
-
-ThisBuild / sonatypeCredentialHost := Sonatype.sonatypeCentralHost
-sonatypeProfileName := "ph.samson"


### PR DESCRIPTION
Remove Sonatype credential host and profile name settings from
publish.sbt as they are no longer required. This cleans up the
build configuration and prevents potential conflicts with the
current publishing process.