### PR TITLE
fix(build): disable packaging of Scala doc in atbp modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,4 +84,5 @@ lazy val adfBuilder = atbpModule("adf-builder")
 def atbpModule(moduleName: String): Project =
   Project(moduleName, file(moduleName))
     .settings(name := s"atbp-$moduleName")
+    .settings(Compile / packageDoc / mappings := Nil)
     .settings(scalacOptions ++= Seq("-no-indent", "-old-syntax"))


### PR DESCRIPTION
Prevent packaging of Scala documentation in the atbp modules by
setting Compile / packageDoc / mappings to Nil. This reduces build
artifacts size and avoids unnecessary doc packaging during build.