### PR TITLE
chore(deps): bump AdfBuilderJava version to 1.7.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys.*
 object Dependencies {
 
   object Versions {
-    val AdfBuilderJava = "1.7.0"
+    val AdfBuilderJava = "1.7.1"
     val CommonMark = "0.24.0"
     val Zio = "2.1.19"
     val ZioConfig = "4.0.4"


### PR DESCRIPTION
Update AdfBuilderJava dependency from 1.7.0 to 1.7.1 to include
latest fixes and improvements. This ensures the project uses the
most recent stable version of the library.