### PR TITLE
feat(traceviz): add TraceViz tool for trace event JSON output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ lazy val root = Project("atbp", file("."))
     name := "atbp-root",
     publish / skip := true
   )
-  .aggregate(cli, confluence, http, jira, md2c, plate)
+  .aggregate(cli, confluence, http, jira, md2c, plate, traceviz)
 
 lazy val cli = atbpModule("cli")
-  .dependsOn(md2c, plate)
+  .dependsOn(md2c, plate, traceviz)
   .enablePlugins(
     DockerPlugin,
     JavaAppPackaging
@@ -73,6 +73,9 @@ lazy val md2c = atbpModule("md2c")
 lazy val plate = atbpModule("plate")
   .dependsOn(jira)
   .settings(Dependencies.plate)
+
+lazy val traceviz = atbpModule("traceviz")
+  .settings(Dependencies.traceviz)
 
 // Pseudo-project to limit usage of Atlassian repo
 lazy val adfBuilder = atbpModule("adf-builder")

--- a/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
@@ -37,7 +37,8 @@ object Main extends ZIOCliDefault {
   val atbp = Command(Name, logging)
     .subcommands(
       Markdown2Confluence.command,
-      Plate.command
+      Plate.command,
+      TraceViz.command
     )
     .withHelp(
       blocks(

--- a/cli/src/main/scala/ph/samson/atbp/cli/TraceViz.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/TraceViz.scala
@@ -1,0 +1,35 @@
+package ph.samson.atbp.cli
+
+import better.files.File
+import ph.samson.atbp.traceviz.TefJson
+import zio.ZIO
+import zio.cli.Args
+import zio.cli.Command
+import zio.cli.Exists.Yes
+import zio.cli.HelpDoc.*
+
+case class TraceViz(source: File) extends ToolCommand {
+  override def run(conf: Conf): ZIO[Any, Throwable, Unit] =
+    ZIO.logSpan("TraceViz") {
+      for {
+        _ <- ZIO.logInfo(s"processing $source")
+        _ <- TefJson.convert(source)
+      } yield ()
+    }
+}
+
+object TraceViz {
+  private val source = Args.file("source", Yes)
+
+  val command: Command[TraceViz] =
+    Command("traceviz", source)
+      .withHelp(
+        blocks(
+          h2("Trace Visualizer"),
+          p(
+            "Render trace timings for visualization in https://ui.perfetto.dev/"
+          )
+        )
+      )
+      .map(TraceViz(_))
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,6 +39,8 @@ object Dependencies {
 
     val pprint = "com.lihaoyi" %% "pprint" % "0.9.0"
 
+    val scalaCsv = "com.github.tototoshi" %% "scala-csv" % "2.0.0"
+
     val zio = "dev.zio" %% "zio" % Zio
 
     val zioCli = "dev.zio" %% "zio-cli" % "0.7.2"
@@ -154,6 +156,12 @@ object Dependencies {
     TestLibs.zioTest,
     TestLibs.zioTestMagnolia,
     TestLibs.zioTestSbt
+  )
+
+  val traceviz = libraryDependencies ++= Seq(
+    zio,
+    betterFiles,
+    scalaCsv
   )
 
   val adfBuilder = libraryDependencies ++= Seq(

--- a/traceviz/src/main/scala/ph/samson/atbp/traceviz/TefJson.scala
+++ b/traceviz/src/main/scala/ph/samson/atbp/traceviz/TefJson.scala
@@ -1,0 +1,69 @@
+package ph.samson.atbp.traceviz
+
+import better.files.File
+import com.github.tototoshi.csv.CSVReader
+import zio.Console
+import zio.ZIO
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
+import scala.util.control.NoStackTrace
+
+/** Writes out Trace Event Format JSON files
+  *
+  * @see
+  *   https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+  */
+object TefJson {
+  private val Fmt =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+  case class Entry(name: String, start: ZonedDateTime, end: ZonedDateTime)
+
+  def convert(source: File) = ZIO.logSpan("convert") {
+    for {
+      rows <- ZIO.attemptBlockingIO {
+        CSVReader.open(source.toJava).all()
+      }
+      entries <- ZIO.foreachPar(rows) {
+        case name :: start :: end :: Nil =>
+          ZIO.attempt(
+            Entry(
+              name,
+              LocalDateTime.parse(start, Fmt).atZone(ZoneId.systemDefault()),
+              LocalDateTime.parse(end, Fmt).atZone(ZoneId.systemDefault())
+            )
+          )
+        case other => ZIO.fail(BadRow(other))
+      }
+      tef = entries.zipWithIndex.flatMap { (entry, idx) =>
+        val startMicros = TimeUnit.SECONDS.toMicros(entry.start.toEpochSecond)
+        val endMicros = TimeUnit.SECONDS.toMicros(entry.end.toEpochSecond)
+        List(
+          s"""{
+             |    "name": "${entry.name}",
+             |    "cat": "PERF",
+             |    "ph": "B",
+             |    "pid": "${source.nameWithoutExtension}",
+             |    "tid": "${entry.name}",
+             |    "ts": $startMicros
+             |}""".stripMargin,
+          s"""{
+             |    "name": "${entry.name}",
+             |    "cat": "PERF",
+             |    "ph": "E",
+             |    "pid": "${source.nameWithoutExtension}",
+             |    "tid": "${entry.name}",
+             |    "ts": $endMicros
+             |}""".stripMargin
+        )
+      }
+      _ <- Console.printLine(tef.mkString("[", ",\n", "]"))
+    } yield ()
+  }
+
+  case class BadRow(row: List[String]) extends Exception with NoStackTrace
+}


### PR DESCRIPTION
Introduce a new traceviz module with a CLI command to convert CSV trace
timings into Trace Event Format JSON for visualization in Perfetto.

- Add TraceViz command to CLI subcommands for easy access
- Implement TefJson object to parse CSV and output TEF JSON events
- Add scala-csv and better-files dependencies for CSV handling
- Integrate traceviz module into build and CLI dependencies

This enables users to generate trace visualizations from CSV timing data,
improving performance analysis capabilities.