### PR TITLE
feat(retext): add retext module for charset re-encoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ lazy val root = Project("atbp", file("."))
     name := "atbp-root",
     publish / skip := true
   )
-  .aggregate(cli, confluence, http, jira, md2c, plate, traceviz)
+  .aggregate(cli, confluence, http, jira, md2c, plate, retext, traceviz)
 
 lazy val cli = atbpModule("cli")
-  .dependsOn(md2c, plate, traceviz)
+  .dependsOn(md2c, plate, retext, traceviz)
   .enablePlugins(
     DockerPlugin,
     JavaAppPackaging
@@ -73,6 +73,9 @@ lazy val md2c = atbpModule("md2c")
 lazy val plate = atbpModule("plate")
   .dependsOn(jira)
   .settings(Dependencies.plate)
+
+lazy val retext = atbpModule("retext")
+  .settings(Dependencies.retext)
 
 lazy val traceviz = atbpModule("traceviz")
   .settings(Dependencies.traceviz)

--- a/cli/src/main/scala/ph/samson/atbp/cli/Retext.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Retext.scala
@@ -1,0 +1,64 @@
+package ph.samson.atbp.cli
+
+import better.files.File
+import ph.samson.atbp.retext.Reencoder
+import zio.Console
+import zio.ZIO
+import zio.cli.Args
+import zio.cli.Command
+import zio.cli.Exists.Either
+import zio.cli.Exists.Yes
+import zio.cli.HelpDoc.*
+import zio.cli.Options
+
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+case class Retext(
+    sources: List[File],
+    targetDir: Option[File],
+    sourceCharset: Option[Charset],
+    targetCharset: Option[Charset]
+) extends ToolCommand {
+  override def run(conf: Conf): ZIO[Any, Throwable, Unit] = {
+    val sourceCs = sourceCharset.getOrElse(better.files.DefaultCharset)
+    val targetCs = targetCharset.getOrElse(StandardCharsets.UTF_8)
+    val tasks = for (source <- sources) yield {
+      val target = targetDir match {
+        case Some(dir) => dir / source.name
+        case None      => source.sibling(s"$targetCs.${source.name}")
+      }
+      Reencoder.transform(source, sourceCs, target, targetCs).as(target)
+    }
+
+    for {
+      targets <- ZIO.collectAllPar(tasks)
+      _ <- Console.printLine(
+        s"Reencoded to $targetCs:\n  ${targets.mkString("\n  ")}"
+      )
+    } yield ()
+  }
+}
+
+object Retext {
+  private val sources = Args.file("source", Yes).atLeast(1)
+  private val targetDir = Options.directory("target", Either).optional
+  private val sourceCharset =
+    Options.text("source-charset").map(Charset.forName).optional
+  private val targetCharset =
+    Options.text("target-charset").map(Charset.forName).optional
+
+  val command: Command[Retext] =
+    Command("retext", targetDir ++ sourceCharset ++ targetCharset, sources)
+      .withHelp(
+        blocks(
+          h2("Reencode text files"),
+          p(
+            "Read the given text FILE(s) and rewrite to a new file using the standard platform line separator."
+          )
+        )
+      )
+      .map { case ((td, sc, tc), s) =>
+        Retext(s.map(File.apply), td.map(File.apply), sc, tc)
+      }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,8 @@ object Dependencies {
       "org.commonmark" % "commonmark-ext-image-attributes" % CommonMark
     val commonmarkExtIns = "org.commonmark" % "commonmark-ext-ins" % CommonMark
 
+    val commonsIo = "commons-io" % "commons-io" % "2.19.0"
+
     val plantuml = "net.sourceforge.plantuml" % "plantuml" % "1.2025.3"
 
     val pprint = "com.lihaoyi" %% "pprint" % "0.9.0"
@@ -156,6 +158,12 @@ object Dependencies {
     TestLibs.zioTest,
     TestLibs.zioTestMagnolia,
     TestLibs.zioTestSbt
+  )
+
+  val retext = libraryDependencies ++= Seq(
+    zio,
+    betterFiles,
+    commonsIo
   )
 
   val traceviz = libraryDependencies ++= Seq(

--- a/retext/src/main/scala/ph/samson/atbp/retext/Reencoder.scala
+++ b/retext/src/main/scala/ph/samson/atbp/retext/Reencoder.scala
@@ -1,0 +1,64 @@
+package ph.samson.atbp.retext
+
+import better.files.File
+import org.apache.commons.io.ByteOrderMark
+import org.apache.commons.io.input.BOMInputStream
+import zio.Task
+import zio.ZIO
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.PrintWriter
+import java.nio.charset.Charset
+
+object Reencoder {
+
+  def transform(
+      source: File,
+      sourceCharset: Charset,
+      target: File,
+      targetCharset: Charset
+  ): Task[Unit] = {
+    val reader = sourceCharset.name() match {
+      case "UTF-8" | "UTF-16" | "UTF-16BE" | "UTF-16LE" | "UTF-32BE" |
+          "UTF-32LE" =>
+        ZIO.attemptBlockingIO(
+          new BufferedReader(
+            new InputStreamReader(
+              BOMInputStream
+                .builder()
+                .setInputStream(source.newInputStream)
+                .setByteOrderMarks(
+                  ByteOrderMark.UTF_8,
+                  ByteOrderMark.UTF_16BE,
+                  ByteOrderMark.UTF_16LE,
+                  ByteOrderMark.UTF_32BE,
+                  ByteOrderMark.UTF_32LE
+                )
+                .get(),
+              sourceCharset
+            )
+          )
+        )
+      case _ =>
+        ZIO.attemptBlockingIO(source.newBufferedReader(using sourceCharset))
+    }
+    val writer = ZIO.attempt(
+      new PrintWriter(target.newBufferedWriter(using targetCharset))
+    )
+
+    ZIO.scoped {
+      for {
+        r <- ZIO.acquireRelease(reader)(reader =>
+          ZIO.succeedBlocking(reader.close())
+        )
+        w <- ZIO.acquireRelease(writer)(writer =>
+          ZIO.succeedBlocking(writer.close())
+        )
+        _ <- ZIO.attemptBlockingIO(
+          r.lines().forEachOrdered(line => w.println(line))
+        )
+      } yield ()
+    }
+  }
+}


### PR DESCRIPTION
Introduce a new retext module that provides functionality to re-encode
text files from one charset to another. Add a CLI command `retext` to
process one or more source files, optionally specifying source and
target charsets and a target directory.

Implement Reencoder utility to handle BOM-aware reading and writing
with specified charsets, ensuring correct handling of UTF encodings.

Update project dependencies and build configuration to include the
new retext module and its dependencies.

This enables users to convert text files between different encodings
with a simple command-line interface, improving text processing
flexibility.