### PR TITLE
ci: add retext/target to compressed artifacts in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Compress target directories
-        run: tar cf targets.tar plate/target target traceviz/target jira/target confluence/target md2c/target cli/target http/target adf-builder/target project/target
+        run: tar cf targets.tar plate/target target traceviz/target jira/target confluence/target md2c/target retext/target cli/target http/target adf-builder/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Include the retext/target directory in the tar archive of target
directories during the CI process. This ensures build outputs from
the retext module are preserved and uploaded as artifacts for later
stages or debugging.