### PR TITLE
feat(md2c): add Extensions transform for Confluence macros

### DIFF
--- a/md2c/src/main/scala/ph/samson/atbp/md2c/Extensions.scala
+++ b/md2c/src/main/scala/ph/samson/atbp/md2c/Extensions.scala
@@ -1,0 +1,58 @@
+package ph.samson.atbp.md2c
+
+import com.atlassian.adf.model.node.CodeBlock
+import com.atlassian.adf.model.node.Doc
+import com.atlassian.adf.model.node.Extension
+import com.atlassian.adf.model.node.Text
+import com.atlassian.adf.model.node.`type`.DocContent
+import com.typesafe.config.ConfigFactory
+
+import scala.jdk.CollectionConverters.*
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+object Extensions {
+
+  def transform(adf: Doc) = {
+
+    adf.transformDescendants(
+      classOf[DocContent],
+      {
+        case codeBlock: CodeBlock =>
+          if (codeBlock.language().orElse("").equals("extension")) {
+            val content: java.util.List[Text] = codeBlock.content()
+            val result: DocContent = Try {
+              val config = ConfigFactory.parseString(
+                content.asScala.map(_.text()).mkString("\n")
+              )
+              val default = Extension
+                .extension()
+                .extensionKey(config.getString("extensionKey"))
+                .extensionType(config.getString("extensionType"))
+              if (config.hasPath("parameters")) {
+                default.parameters(config.getObject("parameters").unwrapped())
+              } else {
+                default
+              }
+            } match {
+              case Success(extension) => extension
+              case Failure(exception) =>
+                exception.printStackTrace()
+                val error = Text.text(exception.getMessage + "\n\n")
+                val newContent = error :: content.asScala.toList
+                codeBlock.replaceContent(newContent.asJava)
+                codeBlock
+            }
+            result
+          } else {
+            codeBlock
+          }
+        case other => other
+      }
+    )
+
+    adf
+  }
+
+}

--- a/md2c/src/main/scala/ph/samson/atbp/md2c/StagedTree.scala
+++ b/md2c/src/main/scala/ph/samson/atbp/md2c/StagedTree.scala
@@ -93,12 +93,13 @@ object StagedTree {
       for {
         Parsed(frontMatter, sourceDoc, contentHash) <- parse(node)
         plantUmlRendered <- PlantUml.transform(sourceDoc)
+        extensionsRendered = Extensions.transform(plantUmlRendered)
         children <- ZIO.foreachPar(children(node))(convert)
       } yield Page(
         node.name,
         node.source,
         frontMatter,
-        plantUmlRendered,
+        extensionsRendered,
         contentHash,
         children
       )


### PR DESCRIPTION
Introduce a new Extensions object that transforms code blocks with the
language "extension" into Atlassian Document Format (ADF) Extension nodes.
This enables embedding configurable extensions within markdown content.

Update StagedTree to apply the Extensions.transform after PlantUml rendering,
ensuring that extension code blocks are processed and converted properly.

This change enhances the document processing pipeline by supporting
custom extension blocks, improving flexibility and extensibility.
refactor: clean up imports and improve code clarity

Remove unused imports and organize existing ones for better readability
in StagedTree.scala and Extensions.scala. This reduces clutter and potential
confusion, making the codebase easier to maintain and understand.
feat: add support for extension code blocks as Confluence macros

Introduce Extensions object to enable instantiation of Confluence macros
via extension code blocks in markdown. This allows embedding macros like
Table of Contents with configurable parameters directly in the source,
improving integration and flexibility for document rendering.