### PR TITLE
feat(md2c): add childPages macro for directory listings

### DIFF
--- a/md2c/src/main/scala/ph/samson/atbp/md2c/Extensions.scala
+++ b/md2c/src/main/scala/ph/samson/atbp/md2c/Extensions.scala
@@ -7,6 +7,7 @@ import com.atlassian.adf.model.node.Text
 import com.atlassian.adf.model.node.`type`.DocContent
 import com.typesafe.config.ConfigFactory
 
+import java.util.Map.of as jMap
 import scala.jdk.CollectionConverters.*
 import scala.util.Failure
 import scala.util.Success
@@ -54,5 +55,31 @@ object Extensions {
 
     adf
   }
+
+  /** Child pages macro
+    *
+    * Display a custom list of content nested under a page.
+    */
+  def childPages: Extension = {
+    Extension
+      .extension()
+      .extensionKey("children")
+      .extensionType("com.atlassian.confluence.macro.core")
+      .parameters(
+        jMap(
+          "macroParams",
+          jMap(
+            "all",
+            value("true"),
+            "depth",
+            value("0"),
+            "allChildren",
+            value("true")
+          )
+        )
+      )
+  }
+
+  private def value(v: String) = jMap("value", v)
 
 }

--- a/md2c/src/main/scala/ph/samson/atbp/md2c/StagedTree.scala
+++ b/md2c/src/main/scala/ph/samson/atbp/md2c/StagedTree.scala
@@ -60,7 +60,11 @@ object StagedTree {
     def parse(node: Node): Task[Parsed] = node match {
       case Directory(name, _, _) =>
         ZIO.succeed(
-          Parsed(FrontMatter.Empty, Doc.doc(Heading.h1(name)), "directory")
+          Parsed(
+            FrontMatter.Empty,
+            Doc.doc(Extensions.childPages),
+            "directory listing"
+          )
         )
       case MarkdownBranch(_, content, _) => Parser.parse(content)
       case MarkdownLeaf(_, content)      => Parser.parse(content)


### PR DESCRIPTION
Replace directory parsing to use a custom childPages macro that
displays nested content as a directory listing. This change improves
the representation of directories by showing their child pages using
a Confluence macro instead of a simple heading. The new macro is
defined in Extensions.scala with parameters to include all children
at depth 0.