### PR TITLE
fix(inspector): handle case with no descendants in done check

### DIFF
--- a/plate/src/main/scala/ph/samson/atbp/plate/Inspector.scala
+++ b/plate/src/main/scala/ph/samson/atbp/plate/Inspector.scala
@@ -151,7 +151,9 @@ object Inspector {
                     val flagReport = s"$reportLine [But NOT DONE: $notDone]"
                     process(next, true, flagReport :: result)
                   }
-                } else if (descendants.forall(_.isDone)) {
+                } else if (
+                  descendants.nonEmpty && descendants.forall(_.isDone)
+                ) {
                   val flagReport = s"$line [ALL DESCENDANTS DONE]"
                   process(next, true, flagReport :: result)
                 } else {


### PR DESCRIPTION
Add a condition to ensure descendants is non-empty before checking if
all are done. This prevents incorrect flagging when there are no
descendants, improving the accuracy of the done status reporting.