### PR TITLE
feat(inspector): include truncated comment text in progress logs

### DIFF
--- a/plate/src/main/scala/ph/samson/atbp/plate/Inspector.scala
+++ b/plate/src/main/scala/ph/samson/atbp/plate/Inspector.scala
@@ -1,6 +1,7 @@
 package ph.samson.atbp.plate
 
 import better.files.File
+import org.jsoup.Jsoup
 import ph.samson.atbp.jira.Client
 import ph.samson.atbp.jira.model.Changelog
 import ph.samson.atbp.jira.model.Changelog.ChangeDetails
@@ -241,7 +242,7 @@ object Inspector {
                 jsdPublic
               ) =>
             updated.isAfter(limit)
-        } map {
+        } flatMap {
           case Comment(
                 self,
                 id,
@@ -252,7 +253,15 @@ object Inspector {
                 renderedBody,
                 jsdPublic
               ) =>
-            s"* <small>📝</small> $updated comment by [${updateAuthor.displayName}]"
+            val body = Jsoup
+              .parseBodyFragment(renderedBody)
+              .text()
+              .take(300)
+              .replace("\n", "_n_")
+            List(
+              s"* <small>📝</small> $updated comment by [${updateAuthor.displayName}]",
+              s"    * $body"
+            )
         }
 
         progressLogs ++ progressComments

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,6 +37,8 @@ object Dependencies {
 
     val commonsIo = "commons-io" % "commons-io" % "2.20.0"
 
+    val jsoup = "org.jsoup" % "jsoup" % "1.21.1"
+
     val plantuml = "net.sourceforge.plantuml" % "plantuml" % "1.2025.4"
 
     val pprint = "com.lihaoyi" %% "pprint" % "0.9.0"
@@ -145,8 +147,9 @@ object Dependencies {
   )
 
   val plate = libraryDependencies ++= Seq(
-    zio,
     betterFiles,
+    jsoup,
+    zio,
     zioConfig,
     zioConfigMagnolia,
     zioConfigTypesafe,


### PR DESCRIPTION
Add Jsoup dependency to parse and extract plain text from rendered
comment bodies. Modify comment processing to include up to 300
characters of cleaned comment text, replacing newlines with "_n_".
This improves readability and context in progress logs by showing
comment content alongside metadata.