### PR TITLE
feat(cli): add MarkdownMerge to merge markdown files

### DIFF
--- a/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
@@ -37,6 +37,7 @@ object Main extends ZIOCliDefault {
   val atbp = Command(Name, logging)
     .subcommands(
       Markdown2Confluence.command,
+      MarkdownMerge.command,
       Plate.command,
       TraceViz.command
     )

--- a/cli/src/main/scala/ph/samson/atbp/cli/MarkdownMerge.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/MarkdownMerge.scala
@@ -1,0 +1,50 @@
+package ph.samson.atbp.cli
+
+import better.files.File
+import zio.Task
+import zio.ZIO
+import zio.cli.Args
+import zio.cli.Command
+import zio.cli.Exists.Either
+import zio.cli.Exists.Yes
+import zio.cli.Options
+
+case class MarkdownMerge(title: String, target: File, sources: List[File])
+    extends ToolCommand {
+  override def run(conf: Conf): Task[Unit] = ZIO.logSpan("mdmerge") {
+    for {
+      lines <- ZIO.foreachPar(sources)(transform)
+      result = s"# $title" :: lines.flatten
+      outFile <- ZIO.attemptBlockingIO {
+        target.overwrite(result.mkString("\n"))
+      }
+    } yield ()
+  }
+
+  def transform(source: File): Task[List[String]] = for {
+    lines <- ZIO.attemptBlockingIO(source.lines.toList)
+  } yield {
+    val title = s"\n## ${source.nameWithoutExtension}\n"
+    title :: lines.map { l =>
+      if (l.startsWith("#")) {
+        "#" + l
+      } else {
+        l
+      }
+    }
+  }
+}
+
+object MarkdownMerge {
+
+  private val title =
+    Options.text("title") ?? "Document title for the merged result"
+  private val target = Options.file("target", Either)
+  private val sources = Args.file(Yes).atLeast(1)
+
+  val command: Command[MarkdownMerge] =
+    Command("mdmerge", title ++ target, sources)
+      .map { case ((title, target), sources) =>
+        MarkdownMerge(title, target, sources.map(identity))
+      }
+}


### PR DESCRIPTION
Introduce a new CLI command `mdmerge` that merges multiple markdown
source files into a single target file with a specified title. Each
source file's content is prefixed with a secondary header derived from
its filename, and existing markdown headers in the content are
incremented to maintain proper hierarchy. This facilitates combining
markdown documents while preserving structure and readability.