### PR TITLE
feat(cli): add Retext command to CLI command list

### DIFF
--- a/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/Main.scala
@@ -38,6 +38,7 @@ object Main extends ZIOCliDefault {
     .subcommands(
       Markdown2Confluence.command,
       Plate.command,
+      Retext.command,
       TraceViz.command
     )
     .withHelp(


### PR DESCRIPTION
Include the Retext command in the main CLI commands to enable
its functionality from the command line. This change improves
the tool's extensibility and provides users with additional
processing options directly via the CLI interface.