### PR TITLE
feat(jira): switch to token-based paginated search

### DIFF
--- a/jira/src/main/scala/ph/samson/atbp/jira/model/SearchRequest.scala
+++ b/jira/src/main/scala/ph/samson/atbp/jira/model/SearchRequest.scala
@@ -9,7 +9,7 @@ case class SearchRequest(
     jql: String,
     fields: List[String],
     maxResults: Int = 50,
-    startAt: Int = 0
+    nextPageToken: Option[String] = None
 )
 
 object SearchRequest {

--- a/jira/src/main/scala/ph/samson/atbp/jira/model/SearchResults.scala
+++ b/jira/src/main/scala/ph/samson/atbp/jira/model/SearchResults.scala
@@ -6,9 +6,8 @@ import zio.schema.codec.BinaryCodec
 import zio.schema.codec.JsonCodec
 
 case class SearchResults(
-    startAt: Int,
-    maxResults: Int,
-    total: Int,
+    isLast: Boolean,
+    nextPageToken: Option[String],
     issues: List[Issue]
 ) {
   def length = issues.length


### PR DESCRIPTION
Replace offset-based pagination with cursor/token-based pagination for
Jira search requests and results. Update SearchRequest to carry an
optional nextPageToken instead of a numeric startAt. Change SearchResults
to include isLast and nextPageToken, and simplify client logic to
recursively follow nextPageToken until completion.

Also:
- Change endpoint path to /search/jql.
- Update doSearch to return a flat List[Issue] and log per-page info.
- Remove complex offset math and parallel tail fetching; rely on token
  chaining to fetch subsequent pages.

This reduces pagination complexity and aligns the client with the new
token-based API semantics.