### PR TITLE
feat(mdmerge): add optional title and confluence TOC macros

### DIFF
--- a/cli/src/main/scala/ph/samson/atbp/cli/MarkdownMerge.scala
+++ b/cli/src/main/scala/ph/samson/atbp/cli/MarkdownMerge.scala
@@ -1,6 +1,8 @@
 package ph.samson.atbp.cli
 
 import better.files.File
+import ph.samson.atbp.cli.MarkdownMerge.TableOfContents
+import ph.samson.atbp.cli.MarkdownMerge.TableOfContents2
 import zio.Task
 import zio.ZIO
 import zio.cli.Args
@@ -9,12 +11,25 @@ import zio.cli.Exists.Either
 import zio.cli.Exists.Yes
 import zio.cli.Options
 
-case class MarkdownMerge(title: String, target: File, sources: List[File])
-    extends ToolCommand {
+case class MarkdownMerge(
+    title: Option[String],
+    target: File,
+    sources: List[File]
+) extends ToolCommand {
   override def run(conf: Conf): Task[Unit] = ZIO.logSpan("mdmerge") {
     for {
       lines <- ZIO.foreachPar(sources)(transform)
-      result = s"# $title" :: lines.flatten
+      result = title match {
+        case None        => TableOfContents :: lines.flatten
+        case Some(value) =>
+          s"# $title" :: TableOfContents2 :: lines.flatten.map { l =>
+            if (l.trim.startsWith("#")) {
+              l.takeWhile(_.isWhitespace) + "#" + l.dropWhile(_.isWhitespace)
+            } else {
+              l
+            }
+          }
+      }
       outFile <- ZIO.attemptBlockingIO {
         target.overwrite(result.mkString("\n"))
       }
@@ -24,23 +39,47 @@ case class MarkdownMerge(title: String, target: File, sources: List[File])
   def transform(source: File): Task[List[String]] = for {
     lines <- ZIO.attemptBlockingIO(source.lines.toList)
   } yield {
-    val title = s"\n## ${source.nameWithoutExtension}\n"
-    title :: lines.map { l =>
-      if (l.startsWith("#")) {
-        "#" + l
-      } else {
-        l
-      }
-    }
+    val title = s"\n# ${source.nameWithoutExtension}\n"
+    title :: lines
   }
 }
 
 object MarkdownMerge {
 
   private val title =
-    Options.text("title") ?? "Document title for the merged result"
+    Options.text("title").optional ?? "Document title for the merged result"
   private val target = Options.file("target", Either)
   private val sources = Args.file(Yes).atLeast(1)
+
+  private val TableOfContents =
+    """```extension
+      |extensionKey = toc
+      |extensionType = com.atlassian.confluence.macro.core
+      |parameters {
+      |    macroParams {
+      |        maxLevel {
+      |            value = "3"
+      |        }
+      |    }
+      |}
+      |```""".stripMargin
+
+  private val TableOfContents2 =
+    """
+      |```extension
+      |extensionKey = toc
+      |extensionType = com.atlassian.confluence.macro.core
+      |parameters {
+      |    macroParams {
+      |        minLevel {
+      |            value = "2"
+      |        }
+      |        maxLevel {
+      |            value = "4"
+      |        }
+      |    }
+      |}
+      |```""".stripMargin
 
   val command: Command[MarkdownMerge] =
     Command("mdmerge", title ++ target, sources)


### PR DESCRIPTION
Make the title option optional and insert Confluence-compatible table
of contents macros when no document title is provided. Preserve
original headings from source files and adjust heading levels when a
title is supplied.

- Change MarkdownMerge.title to Option[String] and make the CLI option
  optional.
- When title is None, prepend a TableOfContents macro block to the
  merged result.
- When title is Some(value), write a top-level "# value" title, insert
  a TableOfContents2 macro, and normalize nested headings by ensuring
  a single leading '#' is present for headings (preserves whitespace).
- Simplify per-file transform to use a single "# filename" section
  header and keep file content lines unchanged.
- Add two reusable TOC macro string constants (TableOfContents and
  TableOfContents2) for different TOC level ranges.

This enables generating Confluence-aware merged markdown with or
without an explicit document title.