### PR TITLE
chore(deps): bump AdfBuilderJava from 1.8.0 to 1.8.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt.Keys.*
 object Dependencies {
 
   object Versions {
-    val AdfBuilderJava = "1.8.0"
+    val AdfBuilderJava = "1.8.4"
     val CommonMark = "0.26.0"
     val Zio = "2.1.21"
     val ZioConfig = "4.0.5"


### PR DESCRIPTION
Update the AdfBuilderJava dependency version to address bugfixes
and improvements introduced in the 1.8.4 release. This keeps the
project aligned with upstream fixes and ensures compatibility with
other updated libraries.